### PR TITLE
feat: Wikipedia・食べログ・ぐるなびへの遷移ボタンを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,5 +7,10 @@
 </head>
 <body>
     <h1>Hello, World!</h1>
+    <nav>
+        <a href="https://ja.wikipedia.org/" target="_blank" rel="noopener noreferrer">Wikipedia</a>
+        <a href="https://tabelog.com/" target="_blank" rel="noopener noreferrer">食べログ</a>
+        <a href="https://www.gnavi.co.jp/" target="_blank" rel="noopener noreferrer">ぐるなび</a>
+    </nav>
 </body>
 </html>


### PR DESCRIPTION
## 概要
- Wikipedia、食べログ、ぐるなびへの外部リンクボタンを`index.html`に追加

## 変更内容
- `<nav>`要素内に3つのリンクボタンを配置
- 各リンクは新しいタブで開く（`target="_blank"`）
- セキュリティ対策として`rel="noopener noreferrer"`を付与

Closes #10